### PR TITLE
fix: Restore relative selection should always return a valid text selection

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gamma-app/y-prosemirror",
-  "version": "1.2.0",
+  "version": "1.2.0-1",
   "description": "Prosemirror bindings for Yjs",
   "main": "./dist/y-prosemirror.cjs",
   "module": "./src/y-prosemirror.js",

--- a/src/plugins/sync-plugin.js
+++ b/src/plugins/sync-plugin.js
@@ -256,8 +256,14 @@ const restoreRelativeSelection = (tr, relSel, binding) => {
         }
       }
 
-      selection = selection || TextSelection.create(tr.doc, anchor, head)
-      tr = tr.setSelection(selection)
+      if (selection) {
+        tr.setSelection(selection)
+      } else {
+        const $anchor = tr.doc.resolve(anchor)
+        const $head = tr.doc.resolve(head)
+        const sel = TextSelection.between($anchor, $head)
+        tr.setSelection(sel)
+      }
     }
   }
 }


### PR DESCRIPTION
TextSelection.create isn't guaranteed to return a valid text selection, and was causing trouble with toggles. TextSelection.between will: https://prosemirror.net/docs/ref/#state.TextSelection^between

Tested locally and it fixes the toggle issue