### PR TITLE
fix: Catch restore relative error

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gamma-app/y-prosemirror",
-  "version": "1.2.3-1",
+  "version": "1.2.3-2",
   "description": "Prosemirror bindings for Yjs",
   "main": "./dist/y-prosemirror.cjs",
   "module": "./src/y-prosemirror.js",

--- a/src/plugins/sync-plugin.js
+++ b/src/plugins/sync-plugin.js
@@ -256,14 +256,19 @@ const restoreRelativeSelection = (tr, relSel, binding) => {
         }
       }
 
-      if (selection) {
-        tr.setSelection(selection)
-      } else {
-        const $anchor = tr.doc.resolve(anchor)
-        const $head = tr.doc.resolve(head)
-        const sel = TextSelection.between($anchor, $head)
-        tr.setSelection(sel)
+      try {
+        if (selection) {
+          tr.setSelection(selection)
+        } else {
+          const $anchor = tr.doc.resolve(anchor)
+          const $head = tr.doc.resolve(head)
+          const sel = TextSelection.between($anchor, $head)
+          tr.setSelection(sel)
+        }
+      } catch (err) {
+        console.error('[@gamma-app/y-prosemirror][sync-plugin] restoreRelativeSelection setSelection error - pos:', anchor, head, 'error:', err)
       }
+      
     }
   }
 }

--- a/src/plugins/sync-plugin.js
+++ b/src/plugins/sync-plugin.js
@@ -268,7 +268,6 @@ const restoreRelativeSelection = (tr, relSel, binding) => {
       } catch (err) {
         console.error('[@gamma-app/y-prosemirror][sync-plugin] restoreRelativeSelection setSelection error - pos:', anchor, head, 'error:', err)
       }
-      
     }
   }
 }


### PR DESCRIPTION
I caught one of my local docs getting emptied out and saw this in the trace:

![image](https://github.com/gamma-app/y-prosemirror/assets/2216153/031e2b7e-26a9-4291-8c0b-cde1ce51c0bb)

Which errored here with out of range resolvePos:
![image](https://github.com/gamma-app/y-prosemirror/assets/2216153/2012f8a5-1e56-4475-9e62-db17162ae5c7)

This is our code, not dmonad's. From: https://github.com/gamma-app/y-prosemirror/pull/12/files

In this case it seems like we'd always rather bail on restoring the selection than let a whole update fail