### PR TITLE
chore: add window capture exception for sentry

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gamma-app/y-prosemirror",
-  "version": "1.2.3-1",
+  "version": "1.2.3-3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@gamma-app/y-prosemirror",
-      "version": "1.2.3-1",
+      "version": "1.2.3-3",
       "license": "MIT",
       "dependencies": {
         "lib0": "^0.2.42"

--- a/src/plugins/sync-plugin.js
+++ b/src/plugins/sync-plugin.js
@@ -252,10 +252,11 @@ const restoreRelativeSelection = (tr, relSel, binding) => {
         try {
           selection = NodeSelection.create(tr.doc, Math.min(anchor, head))
         } catch (err) {
-          const captureException = window['gammaCaptureException']
+          // @ts-ignore
+          const captureException = window.gammaCaptureException
           if (captureException && typeof captureException === 'function') {
             captureException(`[@gamma-app/y-prosemirror][sync-plugin] restoreRelativeSelection NodeSelection error: ${err}`, {
-              extra: { anchor, head, }
+              extra: { anchor, head }
             })
           }
           console.error('[@gamma-app/y-prosemirror][sync-plugin] restoreRelativeSelection NodeSelection error - pos:', anchor, head, 'error:', err)
@@ -269,10 +270,11 @@ const restoreRelativeSelection = (tr, relSel, binding) => {
           return
         }
       } catch (err) {
-        const captureException = window['gammaCaptureException']
+        // @ts-ignore
+        const captureException = window.gammaCaptureException
         if (captureException && typeof captureException === 'function') {
           captureException(`[@gamma-app/y-prosemirror][sync-plugin] restoreRelativeSelection setSelection error: ${err}`, {
-            extra: { anchor, head, }
+            extra: { anchor, head }
           })
         }
         console.error(
@@ -290,10 +292,11 @@ const restoreRelativeSelection = (tr, relSel, binding) => {
         tr.setSelection(createdSelection)
         return
       } catch (err) {
-        const captureException = window['gammaCaptureException']
+        // @ts-ignore
+        const captureException = window.gammaCaptureException
         if (captureException && typeof captureException === 'function') {
           captureException(`[@gamma-app/y-prosemirror][sync-plugin] restoreRelativeSelection setSelection create error: ${err}`, {
-            extra: { anchor, head, }
+            extra: { anchor, head }
           })
         }
         console.error(
@@ -312,10 +315,11 @@ const restoreRelativeSelection = (tr, relSel, binding) => {
         const sel = TextSelection.between($anchor, $head)
         tr.setSelection(sel)
       } catch (err) {
-        const captureException = window['gammaCaptureException']
+        // @ts-ignore
+        const captureException = window.gammaCaptureException
         if (captureException && typeof captureException === 'function') {
           captureException(`[@gamma-app/y-prosemirror][sync-plugin] restoreRelativeSelection setSelection between error: ${err}`, {
-            extra: { anchor, head, }
+            extra: { anchor, head }
           })
         }
         console.error(
@@ -757,36 +761,38 @@ const createNodeFromYElement = (
     mapping.set(el, node)
     return node
   } catch (e) {
-      try {
-        const attrs = el.getAttributes(snapshot)
-        const message =  e.message
-        const jsonElement =  JSON.stringify(el)
-        const jsonAttrs = JSON.stringify(attrs)
-        const jsonChildren = JSON.stringify(children)
-        const captureException = window['gammaCaptureException']
-        if (captureException && typeof captureException === 'function') {
-          captureException(`[@gamma-app/y-prosemirror][sync-plugin] restoreRelativeSelection NodeSelection error: ${message}`, {
-            extra: {
-              message,
-              el: jsonElement,
-              attrs: jsonAttrs,
-              children: jsonChildren,
-            }
-          })
-        }
-        console.error('[@gamma-app/y-prosemirror][sync-plugin] createNodeFromYElement error:', {
-          message,
-          el: jsonElement,
-          attrs: jsonAttrs,
-          children: jsonChildren
+    try {
+      const attrs = el.getAttributes(snapshot)
+      const message = e.message
+      const jsonElement = JSON.stringify(el)
+      const jsonAttrs = JSON.stringify(attrs)
+      const jsonChildren = JSON.stringify(children)
+      // @ts-ignore
+      const captureException = window.gammaCaptureException
+      if (captureException && typeof captureException === 'function') {
+        captureException(`[@gamma-app/y-prosemirror][sync-plugin] restoreRelativeSelection NodeSelection error: ${message}`, {
+          extra: {
+            message,
+            el: jsonElement,
+            attrs: jsonAttrs,
+            children: jsonChildren
+          }
         })
-      } catch (_e) {
-        const captureException = window['gammaCaptureException']
-        if (captureException && typeof captureException === 'function') {
-          captureException(`[@gamma-app/y-prosemirror][sync-plugin] restoreRelativeSelection NodeSelection error: ${_e}`)
-        }
-        console.error('[@gamma-app/y-prosemirror][sync-plugin] createNodeFromYElement error forming error message:', _e)
       }
+      console.error('[@gamma-app/y-prosemirror][sync-plugin] createNodeFromYElement error:', {
+        message,
+        el: jsonElement,
+        attrs: jsonAttrs,
+        children: jsonChildren
+      })
+    } catch (_e) {
+      // @ts-ignore
+      const captureException = window.gammaCaptureException
+      if (captureException && typeof captureException === 'function') {
+        captureException(`[@gamma-app/y-prosemirror][sync-plugin] restoreRelativeSelection NodeSelection error: ${_e}`)
+      }
+      console.error('[@gamma-app/y-prosemirror][sync-plugin] createNodeFromYElement error forming error message:', _e)
+    }
     // an error occured while creating the node. This is probably a result of a concurrent action.
     /** @type {Y.Doc} */ (el.doc).transact((transaction) => {
       /** @type {Y.Item} */ (el._item).delete(transaction)
@@ -826,12 +832,13 @@ const createTextNodesFromYText = (
       nodes.push(schema.text(delta.insert, marks))
     }
   } catch (e) {
-    const captureException = window['gammaCaptureException']
+    // @ts-ignore
+    const captureException = window.gammaCaptureException
     if (captureException && typeof captureException === 'function') {
       captureException(`[@gamma-app/y-prosemirror][sync-plugin] restoreRelativeSelection NodeSelection error: ${e}`, {
         extra: {
           message: e.message,
-          text,
+          text
         }
       })
     }

--- a/src/plugins/sync-plugin.js
+++ b/src/plugins/sync-plugin.js
@@ -252,6 +252,12 @@ const restoreRelativeSelection = (tr, relSel, binding) => {
         try {
           selection = NodeSelection.create(tr.doc, Math.min(anchor, head))
         } catch (err) {
+          const captureException = window['gammaCaptureException']
+          if (captureException && typeof captureException === 'function') {
+            captureException(`[@gamma-app/y-prosemirror][sync-plugin] restoreRelativeSelection NodeSelection error: ${err}`, {
+              extra: { anchor, head, }
+            })
+          }
           console.error('[@gamma-app/y-prosemirror][sync-plugin] restoreRelativeSelection NodeSelection error - pos:', anchor, head, 'error:', err)
         }
       }
@@ -263,6 +269,12 @@ const restoreRelativeSelection = (tr, relSel, binding) => {
           return
         }
       } catch (err) {
+        const captureException = window['gammaCaptureException']
+        if (captureException && typeof captureException === 'function') {
+          captureException(`[@gamma-app/y-prosemirror][sync-plugin] restoreRelativeSelection setSelection error: ${err}`, {
+            extra: { anchor, head, }
+          })
+        }
         console.error(
           '[@gamma-app/y-prosemirror][sync-plugin] restoreRelativeSelection setSelection error - pos:',
           anchor,
@@ -278,6 +290,12 @@ const restoreRelativeSelection = (tr, relSel, binding) => {
         tr.setSelection(createdSelection)
         return
       } catch (err) {
+        const captureException = window['gammaCaptureException']
+        if (captureException && typeof captureException === 'function') {
+          captureException(`[@gamma-app/y-prosemirror][sync-plugin] restoreRelativeSelection setSelection create error: ${err}`, {
+            extra: { anchor, head, }
+          })
+        }
         console.error(
           '[@gamma-app/y-prosemirror][sync-plugin] restoreRelativeSelection setSelection create error - pos:',
           anchor,
@@ -294,6 +312,12 @@ const restoreRelativeSelection = (tr, relSel, binding) => {
         const sel = TextSelection.between($anchor, $head)
         tr.setSelection(sel)
       } catch (err) {
+        const captureException = window['gammaCaptureException']
+        if (captureException && typeof captureException === 'function') {
+          captureException(`[@gamma-app/y-prosemirror][sync-plugin] restoreRelativeSelection setSelection between error: ${err}`, {
+            extra: { anchor, head, }
+          })
+        }
         console.error(
           '[@gamma-app/y-prosemirror][sync-plugin] restoreRelativeSelection setSelection between error - pos:',
           anchor,
@@ -733,17 +757,36 @@ const createNodeFromYElement = (
     mapping.set(el, node)
     return node
   } catch (e) {
-    try {
-      const attrs = el.getAttributes(snapshot)
-      console.error('[@gamma-app/y-prosemirror][sync-plugin] createNodeFromYElement error:', {
-        message: e.message,
-        el: JSON.stringify(el),
-        attrs: JSON.stringify(attrs),
-        children: JSON.stringify(children)
-      })
-    } catch (_e) {
-      console.error('[@gamma-app/y-prosemirror][sync-plugin] createNodeFromYElement error forming error message:', _e)
-    }
+      try {
+        const attrs = el.getAttributes(snapshot)
+        const message =  e.message
+        const jsonElement =  JSON.stringify(el)
+        const jsonAttrs = JSON.stringify(attrs)
+        const jsonChildren = JSON.stringify(children)
+        const captureException = window['gammaCaptureException']
+        if (captureException && typeof captureException === 'function') {
+          captureException(`[@gamma-app/y-prosemirror][sync-plugin] restoreRelativeSelection NodeSelection error: ${message}`, {
+            extra: {
+              message,
+              el: jsonElement,
+              attrs: jsonAttrs,
+              children: jsonChildren,
+            }
+          })
+        }
+        console.error('[@gamma-app/y-prosemirror][sync-plugin] createNodeFromYElement error:', {
+          message,
+          el: jsonElement,
+          attrs: jsonAttrs,
+          children: jsonChildren
+        })
+      } catch (_e) {
+        const captureException = window['gammaCaptureException']
+        if (captureException && typeof captureException === 'function') {
+          captureException(`[@gamma-app/y-prosemirror][sync-plugin] restoreRelativeSelection NodeSelection error: ${_e}`)
+        }
+        console.error('[@gamma-app/y-prosemirror][sync-plugin] createNodeFromYElement error forming error message:', _e)
+      }
     // an error occured while creating the node. This is probably a result of a concurrent action.
     /** @type {Y.Doc} */ (el.doc).transact((transaction) => {
       /** @type {Y.Item} */ (el._item).delete(transaction)
@@ -783,6 +826,15 @@ const createTextNodesFromYText = (
       nodes.push(schema.text(delta.insert, marks))
     }
   } catch (e) {
+    const captureException = window['gammaCaptureException']
+    if (captureException && typeof captureException === 'function') {
+      captureException(`[@gamma-app/y-prosemirror][sync-plugin] restoreRelativeSelection NodeSelection error: ${e}`, {
+        extra: {
+          message: e.message,
+          text,
+        }
+      })
+    }
     console.error('[@gamma-app/y-prosemirror][sync-plugin] createTextNodesFromYText error:', {
       message: e.message,
       text


### PR DESCRIPTION
# Changes

- Add a call to `window.captureException` to send these errors directly to sentry
- The plan is to get this in first, then in Gamma app add the sentry capture exception to the window subsequently. Then remove the lines here: https://github.com/gamma-app/gamma/blob/main/packages/client/sentry.client.config.js#L32-L50

## Any funky stuff?

What's the most questionable thing you're doing here? Maybe something that you'd like reviewed a little more closely or need a 2nd opinion on.

- types! couldn't figure out how to type `Window` in this package

# Context

Of all the console.errors out there, we only want to send these y-prosemirror error logs to Sentry. However, by using the capture console integration, Sentry adds the 'logger' to the scope. Other calls to Sentry.captureException will have this same logger value, and thus get filtered out in our own `beforeSend` logic (see above)/

Relevant code in Sentry:
https://github.com/getsentry/sentry-javascript/blob/8c8a1942d8a7bb8fded162ebc8d5c6096a7dd92e/packages/integrations/src/captureconsole.ts#L49-L56

# Test Plan
- not sure how? But will test in gamma app once this is merged: https://github.com/gamma-app/gamma/pull/10250