### PR TITLE
Traverse the doc to produce more fine-grained transactions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gamma-app/y-prosemirror",
-  "version": "1.2.3-1",
+  "version": "1.2.3-3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@gamma-app/y-prosemirror",
-      "version": "1.2.3-1",
+      "version": "1.2.3-3",
       "license": "MIT",
       "dependencies": {
         "lib0": "^0.2.42"
@@ -21,7 +21,7 @@
         "prosemirror-model": "^1.18.1",
         "prosemirror-schema-basic": "^1.2.0",
         "prosemirror-state": "^1.4.1",
-        "prosemirror-transform": "^1.6.0",
+        "prosemirror-transform": "^1.8.0",
         "prosemirror-view": "^1.26.2",
         "rollup": "^2.59.0",
         "standard": "^17.0.0",
@@ -41,6 +41,7 @@
       "peerDependencies": {
         "prosemirror-model": "^1.7.1",
         "prosemirror-state": "^1.2.3",
+        "prosemirror-transform": "^1.8.0",
         "prosemirror-view": "^1.9.10",
         "y-protocols": "^1.0.1",
         "yjs": "^13.5.38"
@@ -3844,10 +3845,11 @@
       }
     },
     "node_modules/prosemirror-model": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.18.1.tgz",
-      "integrity": "sha512-IxSVBKAEMjD7s3n8cgtwMlxAXZrC7Mlag7zYsAKDndAqnDScvSmp/UdnRTV/B33lTCVU3CCm7dyAn/rVVD0mcw==",
+      "version": "1.25.4",
+      "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.25.4.tgz",
+      "integrity": "sha512-PIM7E43PBxKce8OQeezAs9j4TP+5yDpZVbuurd1h5phUxEKIu+G2a+EUZzIC5nS1mJktDJWzbqS23n1tsAf5QA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "orderedmap": "^2.0.0"
       }
@@ -3883,12 +3885,13 @@
       }
     },
     "node_modules/prosemirror-transform": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/prosemirror-transform/-/prosemirror-transform-1.7.0.tgz",
-      "integrity": "sha512-O4T697Cqilw06Zvc3Wm+e237R6eZtJL/xGMliCi+Uo8VL6qHk6afz1qq0zNjT3eZMuYwnP8ZS0+YxX/tfcE9TQ==",
+      "version": "1.10.5",
+      "resolved": "https://registry.npmjs.org/prosemirror-transform/-/prosemirror-transform-1.10.5.tgz",
+      "integrity": "sha512-RPDQCxIDhIBb1o36xxwsaeAvivO8VLJcgBtzmOwQ64bMtsVFh5SSuJ6dWSxO1UsHTiTXPCgQm3PDJt7p6IOLbw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "prosemirror-model": "^1.0.0"
+        "prosemirror-model": "^1.21.0"
       }
     },
     "node_modules/prosemirror-view": {
@@ -8173,9 +8176,9 @@
       }
     },
     "prosemirror-model": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.18.1.tgz",
-      "integrity": "sha512-IxSVBKAEMjD7s3n8cgtwMlxAXZrC7Mlag7zYsAKDndAqnDScvSmp/UdnRTV/B33lTCVU3CCm7dyAn/rVVD0mcw==",
+      "version": "1.25.4",
+      "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.25.4.tgz",
+      "integrity": "sha512-PIM7E43PBxKce8OQeezAs9j4TP+5yDpZVbuurd1h5phUxEKIu+G2a+EUZzIC5nS1mJktDJWzbqS23n1tsAf5QA==",
       "dev": true,
       "requires": {
         "orderedmap": "^2.0.0"
@@ -8212,12 +8215,12 @@
       }
     },
     "prosemirror-transform": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/prosemirror-transform/-/prosemirror-transform-1.7.0.tgz",
-      "integrity": "sha512-O4T697Cqilw06Zvc3Wm+e237R6eZtJL/xGMliCi+Uo8VL6qHk6afz1qq0zNjT3eZMuYwnP8ZS0+YxX/tfcE9TQ==",
+      "version": "1.10.5",
+      "resolved": "https://registry.npmjs.org/prosemirror-transform/-/prosemirror-transform-1.10.5.tgz",
+      "integrity": "sha512-RPDQCxIDhIBb1o36xxwsaeAvivO8VLJcgBtzmOwQ64bMtsVFh5SSuJ6dWSxO1UsHTiTXPCgQm3PDJt7p6IOLbw==",
       "dev": true,
       "requires": {
-        "prosemirror-model": "^1.0.0"
+        "prosemirror-model": "^1.21.0"
       }
     },
     "prosemirror-view": {

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
   "peerDependencies": {
     "prosemirror-model": "^1.7.1",
     "prosemirror-state": "^1.2.3",
+    "prosemirror-transform": "^1.8.0",
     "prosemirror-view": "^1.9.10",
     "y-protocols": "^1.0.1",
     "yjs": "^13.5.38"
@@ -72,7 +73,7 @@
     "prosemirror-model": "^1.18.1",
     "prosemirror-schema-basic": "^1.2.0",
     "prosemirror-state": "^1.4.1",
-    "prosemirror-transform": "^1.6.0",
+    "prosemirror-transform": "^1.8.0",
     "prosemirror-view": "^1.26.2",
     "rollup": "^2.59.0",
     "standard": "^17.0.0",

--- a/src/plugins/sync-plugin.js
+++ b/src/plugins/sync-plugin.js
@@ -127,6 +127,29 @@ const diffDocs = (source, target, sourcePos, tr) => {
 }
 
 /**
+ * Recursively populate the mapping between Yjs types and ProseMirror nodes.
+ * This assumes the Yjs fragment and ProseMirror node are already in sync.
+ *
+ * @param {Y.XmlFragment} yFragment
+ * @param {PModel.Node} pNode
+ * @param {ProsemirrorMapping} mapping
+ */
+const populateMapping = (yFragment, pNode, mapping) => {
+  mapping.set(yFragment, pNode)
+  const yChildren = yFragment.toArray()
+  const pChildren = normalizePNodeContent(pNode)
+  for (let i = 0; i < yChildren.length && i < pChildren.length; i++) {
+    const yChild = yChildren[i]
+    const pChild = pChildren[i]
+    if (yChild instanceof Y.XmlElement && !(pChild instanceof Array)) {
+      populateMapping(yChild, pChild, mapping)
+    } else if (yChild instanceof Y.XmlText && pChild instanceof Array) {
+      mapping.set(yChild, pChild)
+    }
+  }
+}
+
+/**
  * @param {Y.Item} item
  * @param {Y.Snapshot} [snapshot]
  */
@@ -711,7 +734,7 @@ export class ProsemirrorBinding {
       }
       this.prosemirrorView.dispatch(tr)
       this.mapping.clear()
-      updateYFragment(this.doc, this.type, this.prosemirrorView.state.doc, this.mapping)
+      populateMapping(this.type, this.prosemirrorView.state.doc, this.mapping)
     })
   }
 

--- a/src/plugins/sync-plugin.js
+++ b/src/plugins/sync-plugin.js
@@ -13,13 +13,79 @@ import * as object from 'lib0/object'
 import * as random from 'lib0/random'
 import * as set from 'lib0/set'
 import * as PModel from 'prosemirror-model'
-import { NodeSelection, Plugin, TextSelection } from 'prosemirror-state'; // eslint-disable-line
+import { NodeSelection, Plugin, TextSelection, Transaction } from 'prosemirror-state'; // eslint-disable-line
+import { DocAttrStep } from 'prosemirror-transform'
 import * as Y from 'yjs'
 import {
   absolutePositionToRelativePosition,
   relativePositionToAbsolutePosition
 } from '../lib.js'
 import { ySyncPluginKey, yUndoPluginKey } from './keys.js'
+
+/**
+ * @param {PModel.Node | undefined} source
+ * @param {PModel.Node | undefined} target
+ * @param {number} sourcePos
+ * @param {Transaction} tr
+ */
+const diffDocs = (source, target, sourcePos, tr) => {
+  const mappedPos = sourcePos === -1 ? { pos: 0, deleted: false } : tr.mapping.mapResult(sourcePos)
+  if (mappedPos.deleted) return
+  const inter = sourcePos === -1 ? tr.doc : tr.doc.resolve(mappedPos.pos).nodeAfter
+  const interSize = sourcePos === -1 ? inter.content.size : inter?.nodeSize ?? 0
+
+  if (!source) {
+    tr.insert(mappedPos.pos, target)
+    return tr
+  }
+
+  if (!target) {
+    tr.delete(mappedPos.pos, mappedPos.pos + inter.nodeSize)
+    return tr
+  }
+
+  if (source.type !== target.type) {
+    tr.replace(
+      mappedPos.pos,
+      mappedPos.pos + interSize,
+      new PModel.Slice(PModel.Fragment.from(target), 0, 0)
+    )
+    return tr
+  }
+
+  if (!source.isText && !source.hasMarkup(target.type, target.attrs, target.marks)) {
+    if (sourcePos === -1) {
+      for (const [attr, value] of Object.entries(target.attrs)) {
+        tr.step(new DocAttrStep(attr, value))
+      }
+    } else {
+      tr.setNodeMarkup(
+        mappedPos.pos,
+        target.type,
+        target.attrs,
+        target.marks
+      )
+    }
+  }
+
+  if ((source.isLeaf || target.isLeaf) && !source.eq(target)) {
+    tr.replace(
+      mappedPos.pos,
+      mappedPos.pos + interSize,
+      new PModel.Slice(PModel.Fragment.from(target), 0, 0)
+    )
+    return tr
+  }
+
+  const childCount = Math.max(source.childCount, target.childCount)
+  let childSourcePos = sourcePos === -1 ? 0 : sourcePos + (source.isBlock ? 1 : 0)
+  for (let i = 0; i < childCount; i++) {
+    diffDocs(source.maybeChild(i), target.maybeChild(i), childSourcePos, tr)
+    childSourcePos += source.maybeChild(i)?.nodeSize ?? 0
+  }
+
+  return tr
+}
 
 /**
  * @param {Y.Item} item
@@ -590,11 +656,12 @@ export class ProsemirrorBinding {
         )
       ).filter((n) => n !== null)
       // @ts-ignore
-      let tr = this._tr.replace(
+      const target = this._tr.replace(
         0,
         this.prosemirrorView.state.doc.content.size,
         new PModel.Slice(PModel.Fragment.from(fragmentContent), 0, 0)
-      )
+      ).doc
+      let tr = diffDocs(this.prosemirrorView.state.doc, target, -1, this._tr)
       restoreRelativeSelection(tr, this.beforeTransactionSelection, this)
       tr = tr.setMeta(ySyncPluginKey, { isChangeOrigin: true, isUndoRedoOperation: transaction.origin instanceof Y.UndoManager })
       if (

--- a/src/plugins/sync-plugin.js
+++ b/src/plugins/sync-plugin.js
@@ -23,34 +23,58 @@ import {
 import { ySyncPluginKey, yUndoPluginKey } from './keys.js'
 
 /**
+ * @param {PModel.ResolvedPos} $from
+ * @param {PModel.ResolvedPos} $to
+ * @param {PModel.Fragment} fragment
+ * @param {Transaction} tr
+ * @return {boolean}
+ */
+const safeReplace = ($from, $to, fragment, tr) => {
+  // If we encounter a non-trivial replacement, fail up
+  // and have the parent handle it. Otherwise ProseMirror
+  // will adjust the document in unpredictable ways
+  // to enforce the schema
+  if (!$from.parent.canReplace($from.index(), $to.index(), fragment)) {
+    return false
+  }
+
+  tr.replace(
+    $from.pos,
+    $to.pos,
+    new PModel.Slice(fragment, 0, 0)
+  )
+  return true
+}
+
+/**
  * @param {PModel.Node | undefined} source
  * @param {PModel.Node | undefined} target
  * @param {number} sourcePos
  * @param {Transaction} tr
+ * @return {boolean}
  */
 const diffDocs = (source, target, sourcePos, tr) => {
   const mappedPos = sourcePos === -1 ? { pos: 0, deleted: false } : tr.mapping.mapResult(sourcePos)
-  if (mappedPos.deleted) return
+  if (mappedPos.deleted) return false
   const inter = sourcePos === -1 ? tr.doc : tr.doc.resolve(mappedPos.pos).nodeAfter
   const interSize = sourcePos === -1 ? inter.content.size : inter?.nodeSize ?? 0
 
   if (!source) {
     tr.insert(mappedPos.pos, target)
-    return tr
+    return true
   }
 
   if (!target) {
     tr.delete(mappedPos.pos, mappedPos.pos + inter.nodeSize)
-    return tr
+    return true
   }
 
   if (source.type !== target.type) {
-    tr.replace(
-      mappedPos.pos,
-      mappedPos.pos + interSize,
-      new PModel.Slice(PModel.Fragment.from(target), 0, 0)
-    )
-    return tr
+    const $from = tr.doc.resolve(mappedPos.pos)
+    const $to = tr.doc.resolve(mappedPos.pos + interSize)
+    const fragment = PModel.Fragment.from(target)
+
+    return safeReplace($from, $to, fragment, tr)
   }
 
   if (!source.isText && !source.hasMarkup(target.type, target.attrs, target.marks)) {
@@ -74,17 +98,32 @@ const diffDocs = (source, target, sourcePos, tr) => {
       mappedPos.pos + interSize,
       new PModel.Slice(PModel.Fragment.from(target), 0, 0)
     )
-    return tr
+    return true
   }
 
   const childCount = Math.max(source.childCount, target.childCount)
-  let childSourcePos = sourcePos === -1 ? 0 : sourcePos + (source.isBlock ? 1 : 0)
+  let childSourcePos = sourcePos === -1 ? 0 : sourcePos + (source.isLeaf ? 0 : 1)
   for (let i = 0; i < childCount; i++) {
-    diffDocs(source.maybeChild(i), target.maybeChild(i), childSourcePos, tr)
+    const diffed = diffDocs(source.maybeChild(i), target.maybeChild(i), childSourcePos, tr)
+    if (!diffed) {
+      // Recompute the mapped position, since the transaction may have since been
+      // updated by previous child replacements
+      const mappedPos = sourcePos === -1 ? { pos: 0, deleted: false } : tr.mapping.mapResult(sourcePos)
+      if (mappedPos.deleted) return false
+
+      const inter = sourcePos === -1 ? tr.doc : tr.doc.resolve(mappedPos.pos).nodeAfter
+      const interSize = sourcePos === -1 ? inter.content.size : inter?.nodeSize ?? 0
+
+      const $from = tr.doc.resolve(mappedPos.pos)
+      const $to = tr.doc.resolve(mappedPos.pos + interSize)
+      const fragment = PModel.Fragment.from(target)
+
+      return safeReplace($from, $to, fragment, tr)
+    }
     childSourcePos += source.maybeChild(i)?.nodeSize ?? 0
   }
 
-  return tr
+  return true
 }
 
 /**
@@ -661,7 +700,8 @@ export class ProsemirrorBinding {
         this.prosemirrorView.state.doc.content.size,
         new PModel.Slice(PModel.Fragment.from(fragmentContent), 0, 0)
       ).doc
-      let tr = diffDocs(this.prosemirrorView.state.doc, target, -1, this._tr)
+      let tr = this._tr
+      diffDocs(this.prosemirrorView.state.doc, target, -1, tr)
       restoreRelativeSelection(tr, this.beforeTransactionSelection, this)
       tr = tr.setMeta(ySyncPluginKey, { isChangeOrigin: true, isUndoRedoOperation: transaction.origin instanceof Y.UndoManager })
       if (

--- a/src/plugins/sync-plugin.js
+++ b/src/plugins/sync-plugin.js
@@ -54,7 +54,7 @@ const safeReplace = ($from, $to, fragment, tr) => {
  * @return {boolean}
  */
 const diffDocs = (source, target, sourcePos, tr) => {
-  const mappedPos = sourcePos === -1 ? { pos: 0, deleted: false } : tr.mapping.mapResult(sourcePos)
+  const mappedPos = sourcePos === -1 ? { pos: 0, deleted: false } : tr.mapping.mapResult(sourcePos, 1)
   if (mappedPos.deleted) return false
   const inter = sourcePos === -1 ? tr.doc : tr.doc.resolve(mappedPos.pos).nodeAfter
   const interSize = sourcePos === -1 ? inter.content.size : inter?.nodeSize ?? 0
@@ -108,7 +108,7 @@ const diffDocs = (source, target, sourcePos, tr) => {
     if (!diffed) {
       // Recompute the mapped position, since the transaction may have since been
       // updated by previous child replacements
-      const mappedPos = sourcePos === -1 ? { pos: 0, deleted: false } : tr.mapping.mapResult(sourcePos)
+      const mappedPos = sourcePos === -1 ? { pos: 0, deleted: false } : tr.mapping.mapResult(sourcePos, 1)
       if (mappedPos.deleted) return false
 
       const inter = sourcePos === -1 ? tr.doc : tr.doc.resolve(mappedPos.pos).nodeAfter
@@ -710,6 +710,8 @@ export class ProsemirrorBinding {
         tr.scrollIntoView()
       }
       this.prosemirrorView.dispatch(tr)
+      this.mapping.clear()
+      updateYFragment(this.doc, this.type, this.prosemirrorView.state.doc, this.mapping)
     })
   }
 


### PR DESCRIPTION
y-prosemirror does a full document replace on every single remote edit. This is kind of wild as a strategy, and unfortunately it triggers a pathological edge case in React ProseMirror, which forces the entire React tree to be remounted (not just re-rendered) on every change, which is very, very slow. It's possible to detect this case in React ProseMirror, but our ability to mitigate is limited. We could diff the doc in order to preserve the React keys for nodes that haven't changed, but we still get new Node instances for every node in the tree, which means that every node view component will still re-render. This is significantly better than remounting, but will still be too expensive for very large documents.

But if we diff the doc _here_, in y-prosemirror, we can produce a much smaller, more targeted transaction that only replaces the nodes that have actually changed.

We accomplish this by simply traversing the old and new docs in tandem, and replacing subtrees when we encounter differences. The result is that changing the text of a paragraph produces a step that only replaces that text node, rather than replacing the entire doc.

I linked this change in for testing and collab editing is super snappy now :)