### PR TITLE
Bump version number to 1.2.3-5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gamma-app/y-prosemirror",
-  "version": "1.2.3-4",
+  "version": "1.2.3-5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@gamma-app/y-prosemirror",
-      "version": "1.2.3-4",
+      "version": "1.2.3-5",
       "license": "MIT",
       "dependencies": {
         "lib0": "^0.2.42"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gamma-app/y-prosemirror",
-  "version": "1.2.3-4",
+  "version": "1.2.3-5",
   "description": "Prosemirror bindings for Yjs",
   "main": "./dist/y-prosemirror.cjs",
   "module": "./src/y-prosemirror.js",


### PR DESCRIPTION
Bump version number to next version of our fork, 1.2.3-5, after this change: https://github.com/gamma-app/y-prosemirror/pull/22