### PR TITLE
Skip identity-attr overwrites in updateYFragment middle-diff

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gamma-app/y-prosemirror",
-  "version": "1.2.3-5",
+  "version": "1.2.3-6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@gamma-app/y-prosemirror",
-      "version": "1.2.3-5",
+      "version": "1.2.3-6",
       "license": "MIT",
       "dependencies": {
         "lib0": "^0.2.42"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gamma-app/y-prosemirror",
-  "version": "1.2.3-5",
+  "version": "1.2.3-6",
   "description": "Prosemirror bindings for Yjs",
   "main": "./dist/y-prosemirror.cjs",
   "module": "./src/y-prosemirror.js",

--- a/src/plugins/sync-plugin.js
+++ b/src/plugins/sync-plugin.js
@@ -1198,6 +1198,12 @@ export const updateYFragment = (y, yDomFragment, pNode, mapping) => {
     for (const key in pAttrs) {
       if (pAttrs[key] !== null) {
         if (yDomAttrs[key] !== pAttrs[key] && key !== 'ychange') {
+          if (
+            (key === 'id' || key === 'itemId') &&
+            yDomAttrs[key] !== undefined
+          ) {
+            continue
+          }
           yDomFragment.setAttribute(key, pAttrs[key])
         }
       } else {

--- a/tests/y-prosemirror.test.js
+++ b/tests/y-prosemirror.test.js
@@ -357,9 +357,8 @@ const cardSchema = new Schema({
 })
 
 /**
- * Regression for https://github.com/gamma-app/y-prosemirror/pull/24 — Y
- * identity attrs (`id`, `itemId`) on existing elements must survive the
- * middle-diff fallback path that rewrote them to neighbors' ids in prod.
+ * Identity attrs (`id`, `itemId`) on existing Y elements are preserved by
+ * `updateYFragment`; non-identity attrs are still updated.
  *
  * @param {t.TestCase} _tc
  */
@@ -387,7 +386,7 @@ export const testIdentityAttrsPreservedOnExistingYElement = (_tc) => {
 }
 
 /**
- * Inverse of the above: confirms the patch does not break clean inserts.
+ * Identity attrs are assigned on fresh Y elements (no existing value).
  *
  * @param {t.TestCase} _tc
  */

--- a/tests/y-prosemirror.test.js
+++ b/tests/y-prosemirror.test.js
@@ -339,8 +339,6 @@ export const testAddToHistoryIgnore = (_tc) => {
   )
 }
 
-// Minimal schema with stable identity attrs (`id`, `itemId`) on a `card` node,
-// modeling Gamma's editor schema for the regression tests below.
 const cardSchema = new Schema({
   nodes: {
     doc: { content: 'card+' },
@@ -359,14 +357,9 @@ const cardSchema = new Schema({
 })
 
 /**
- * Regression for https://github.com/gamma-app/y-prosemirror/pull/24.
- *
- * When `updateYFragment`'s prefix/suffix anchor walks both fail and the
- * middle-diff loop pairs a Y XmlElement with a different PM node by
- * `nodeName` only, the recursive call must NOT overwrite identity attrs
- * (`id`, `itemId`) on the existing Y element. Doing so produced a cascade
- * corruption in production where stable card ids were rewritten to neighbors'
- * ids on every subsequent local edit.
+ * Regression for https://github.com/gamma-app/y-prosemirror/pull/24 — Y
+ * identity attrs (`id`, `itemId`) on existing elements must survive the
+ * middle-diff fallback path that rewrote them to neighbors' ids in prod.
  *
  * @param {t.TestCase} _tc
  */
@@ -394,10 +387,7 @@ export const testIdentityAttrsPreservedOnExistingYElement = (_tc) => {
 }
 
 /**
- * Companion to the above: identity attrs MUST still be assigned on fresh Y
- * elements (no existing value). The early-skip in the patch is gated on
- * `yDomAttrs[key] !== undefined`, so clean inserts must continue to receive
- * their initial id assignment.
+ * Inverse of the above: confirms the patch does not break clean inserts.
  *
  * @param {t.TestCase} _tc
  */

--- a/tests/y-prosemirror.test.js
+++ b/tests/y-prosemirror.test.js
@@ -20,7 +20,9 @@ import { EditorState, Plugin, TextSelection, NodeSelection } from 'prosemirror-s
 import { EditorView } from 'prosemirror-view'
 import * as basicSchema from 'prosemirror-schema-basic'
 import { findWrapping } from 'prosemirror-transform'
+import { Schema } from 'prosemirror-model'
 import { schema as complexSchema } from './complexSchema.js'
+import { updateYFragment } from '../src/plugins/sync-plugin.js'
 
 const schema = /** @type {any} */ (basicSchema.schema)
 
@@ -335,6 +337,86 @@ export const testAddToHistoryIgnore = (_tc) => {
       yxml.get(0).toString() === '<paragraph>abc</paragraph>',
     'insertion (1) was undone'
   )
+}
+
+// Minimal schema with stable identity attrs (`id`, `itemId`) on a `card` node,
+// modeling Gamma's editor schema for the regression tests below.
+const cardSchema = new Schema({
+  nodes: {
+    doc: { content: 'card+' },
+    card: {
+      attrs: {
+        id: { default: null },
+        itemId: { default: null },
+        foo: { default: null }
+      },
+      content: 'inline*',
+      parseDOM: [{ tag: 'card' }],
+      toDOM: () => ['card', 0]
+    },
+    text: { group: 'inline' }
+  }
+})
+
+/**
+ * Regression for https://github.com/gamma-app/y-prosemirror/pull/24.
+ *
+ * When `updateYFragment`'s prefix/suffix anchor walks both fail and the
+ * middle-diff loop pairs a Y XmlElement with a different PM node by
+ * `nodeName` only, the recursive call must NOT overwrite identity attrs
+ * (`id`, `itemId`) on the existing Y element. Doing so produced a cascade
+ * corruption in production where stable card ids were rewritten to neighbors'
+ * ids on every subsequent local edit.
+ *
+ * @param {t.TestCase} _tc
+ */
+export const testIdentityAttrsPreservedOnExistingYElement = (_tc) => {
+  const ydoc = new Y.Doc()
+  const yFrag = ydoc.get('test', Y.XmlFragment)
+  const yCard = new Y.XmlElement('card')
+  yCard.setAttribute('id', 'y-original-id')
+  yCard.setAttribute('itemId', 'y-original-itemid')
+  yCard.setAttribute('foo', 'y-foo')
+  yFrag.insert(0, [yCard])
+
+  const pmCard = cardSchema.node('card', {
+    id: 'pm-cascading-id',
+    itemId: 'pm-cascading-itemid',
+    foo: 'pm-foo'
+  })
+  const pmDoc = cardSchema.node('doc', null, [pmCard])
+
+  updateYFragment(ydoc, yFrag, pmDoc, new Map())
+
+  t.assert(yCard.getAttribute('id') === 'y-original-id', 'id preserved on existing Y element')
+  t.assert(yCard.getAttribute('itemId') === 'y-original-itemid', 'itemId preserved on existing Y element')
+  t.assert(yCard.getAttribute('foo') === 'pm-foo', 'non-identity attr is updated')
+}
+
+/**
+ * Companion to the above: identity attrs MUST still be assigned on fresh Y
+ * elements (no existing value). The early-skip in the patch is gated on
+ * `yDomAttrs[key] !== undefined`, so clean inserts must continue to receive
+ * their initial id assignment.
+ *
+ * @param {t.TestCase} _tc
+ */
+export const testIdentityAttrsAssignedOnFreshYElement = (_tc) => {
+  const ydoc = new Y.Doc()
+  const yFrag = ydoc.get('test', Y.XmlFragment)
+  const yCard = new Y.XmlElement('card')
+  yFrag.insert(0, [yCard])
+
+  const pmCard = cardSchema.node('card', {
+    id: 'fresh-id',
+    itemId: 'fresh-itemid'
+  })
+  const pmDoc = cardSchema.node('doc', null, [pmCard])
+
+  updateYFragment(ydoc, yFrag, pmDoc, new Map())
+
+  t.assert(yCard.getAttribute('id') === 'fresh-id', 'id assigned on fresh Y element')
+  t.assert(yCard.getAttribute('itemId') === 'fresh-itemid', 'itemId assigned on fresh Y element')
 }
 
 const createNewProsemirrorViewWithSchema = (y, schema, undoManager = false) => {


### PR DESCRIPTION
## Summary

`updateYFragment` in `src/plugins/sync-plugin.js` unconditionally overwrites every PM attr onto the matched Y element. When the prefix/suffix anchor walks both fail and the middle-diff loop falls back to pairing cards by `nodeName` only, this overwrites stable identity attrs (`id`, `itemId`) on existing Y elements with the wrong PM node's id — producing the cascade corruption observed in two recent gamma prod incidents.

This patch adds an early-skip on identity-attr writes when the Y element already has that attribute defined. Fresh Y elements are unaffected (`yDomAttrs[key] === undefined` at first assignment), so clean inserts still get their initial id.

## How this manifests in gamma

Two gamma docs got CRDT-corrupted in the last 10 days: `fvkf2otocpgb5v1` (Kath, 2026-04-28) and `dz47mccmnfylaqm` (Kath, 2026-05-07). The damage shape:

**Existing card ids get overwritten with a neighbor's id.** In doc 2 the cascade affected 32 of 46 cards starting at position 15. Each affected card's id was rewritten to the id its previous sibling held before the cascade — so post-cascade card[15] holds card[14]'s pre-cascade id, card[16] holds card[15]'s pre-cascade id, etc. Card[14] kept its original id, which means card[14] and card[15] now share an id. That single duplicate-id pair at the cascade boundary is the load-bearing damage: anything that resolves cards by id (filmstrip nav, share-link anchors, gamma's own `editCardById` lookup, undo refs) collides on those two cards. The other ~30 affected cards have wrong-but-unique ids — pointing to a neighbor's identity. Doc 1 has the symmetric shape: each affected card holds the id of the card N positions ahead, with one duplicate-id pair at the boundary.

**`cardLayoutItem` children get added and removed unevenly across adjacent siblings.** The middle-diff loop recurses into card children. The same broken pairing produces uneven `delete` and `insert` ops at the child level. In doc 2, several adjacent card pairs ended up with one card going from `[accent, layout]` to `[accent]` (lost its `cardLayoutItem`, now lone-accent) while the next card went from `[layout]` to `[layout, layout]` (got an extra `cardLayoutItem` inserted). The deleted and inserted items aren't the same Y element — they're independent Y ops produced by the same broken pair recursion.

**Surplus children at the boundary of the misaligned range get balanced.** When the middle-diff finishes, if PM had more children than Y in the misaligned range the surplus get `insert`'d into Y; if Y had more, the surplus Y children get `delete`'d (tombstoned). Doc 2 ended with 2 brand-new Y cards appended at sibling end (`x9lqjaedw9ifyeo`, `xag9fadmw0ca2b1`); doc 1 ended with 3 Y cards entirely deleted mid-deck, including the buddy edit's actual target card (`jv2aiwnq0nbhcmn`) and its sibling-before/after.

**The cascade extended across multiple user transactions in the same doc.** Doc 2's 32-card outcome landed in 3 time-separated runs of the cascade (corruptor clock ranges 10687-10693, 11104-11198, 11412-13254) — three distinct user transactions during a 70-minute editing session, each one enlarging the affected set. Each run was an independent local PM transaction whose `_prosemirrorChanged` re-entered the broken middle-diff because the mapping remained misaligned.

## Why the mapping ends up misaligned in gamma

The cascade only fires when the binding's `mapping: Map<Y.XmlElement, PModel.Node>` is misaligned at the moment a local PM transaction commits — both anchor walks fail, the middle-diff falls into nodeName-only pairing, and `setAttribute('id', …)` writes the wrong neighbor's id onto the Y element. We've reproduced the cascade synthetically by injecting PM-id divergence directly, but we have not nailed down the exact prod sequence that creates the misalignment. Two gamma-side conditions correlate with the observed incidents:

1. **Bulk Buddy edits produce N back-to-back PM transactions per user gesture.** Buddy's `editAllCards` returns N suggestions and the client auto-applies each via `replaceCardJSONById` in a loop, each one its own `chain().insertContentAt().run()` and therefore its own `_prosemirrorChanged` → `updateYFragment` call. Doc 2's incident immediately followed a 45-suggestion `editAllCards`. Doc 1's was a single `editCardById` followed by selective-accept replay (which loads a checkpoint, then re-applies suggestions one at a time). Both create lots of fresh PM card refs in quick succession and many opportunities for transactions to interleave.

2. **`_typeChanged` rebuilds the mapping from scratch on every remote update.** The fork's `_typeChanged` (introduced in #20 to avoid React remounts under `@handlewithcare/react-prosemirror`) calls `mapping.clear() + populateMapping(...)` whenever a remote Y fragment update arrives. `populateMapping` pairs `yChildren[i]` with `pChildren[i]` strictly by array index, with no length check or identity verification. Hocuspocus pod bounces, network reconnects, and selective-accept's checkpoint reload all hit this rebuild path. Doc 2 had a hocuspocus pod unload/reload at 14:24:44 — within the 70-minute window across which the cascade landed.

Either condition alone may not produce a misalignment. The combination of bulk-apply churning PM refs while remote updates rebuild the mapping by index is the candidate sequence. We don't yet have a deterministic UI repro. The patch in this PR is robust to any upstream sequence that lands `updateYFragment` on a misaligned mapping.

## How the patch addresses it

`src/plugins/sync-plugin.js` lines 1198-1206 — the attribute-write loop inside `updateYFragment`:

```js
if (yDomAttrs[key] !== pAttrs[key] && key !== 'ychange') {
  if ((key === 'id' || key === 'itemId') && yDomAttrs[key] !== undefined) {
    continue
  }
  yDomFragment.setAttribute(key, pAttrs[key])
}
```

`yDomAttrs[key] !== undefined` is the load-bearing predicate. It distinguishes:

- **Existing Y element** (`yDomAttrs[key]` already has a value): skip the overwrite. Identity attrs name the entity; we never want to rewrite them under a misaligned pair, even if the pair "looks" updateable by nodeName.
- **Freshly-created Y element** (`yDomAttrs[key] === undefined`): let the write through. The element was just created in this transaction and has no prior identity, so the initial assignment must succeed.

This stops the visible corruption regardless of how the mapping got misaligned. The middle-diff may still produce structural ops (delete/insert of surplus children, attr writes on non-identity attrs), but the cascade-defining behavior — `setAttribute('id', neighbor's id)` on an existing Y card, sibling-id duplicates, layoutItem child mismatches riding on the same recursion — is gated on `setAttribute('id', …)` succeeding, which the patch refuses for already-set identity attrs.

A stricter alternative would be `mapping.get(yDomFragment) !== pNode` — refuse identity-attr writes on any pair that wasn't anchored by mapped identity (i.e. reached via positional fallback). That's a more semantic guard and worth considering during review. The current `yDomAttrs[key] !== undefined` form is simpler, doesn't depend on the mapping being correct, and is sufficient for both the synthetic repro and the prod failure modes.

## Test plan

- [x] `npm test` — 16 tests pass, including two new regressions:
  - `testIdentityAttrsPreservedOnExistingYElement` (fails without the patch)
  - `testIdentityAttrsAssignedOnFreshYElement` (confirms clean inserts still set initial id)
- [x] Regression power verified locally: `git checkout HEAD~1 -- src/plugins/sync-plugin.js && npm test` → 1 failure on `testIdentityAttrsPreservedOnExistingYElement`. Restore patch → green.
- [x] Synthetic harness reproduces the cascade against an unpatched fork (30 setAttribute writes) and prevents it under the patch (0 writes).
- [x] Captured prod cascade replays through a real `ProsemirrorBinding` against an unpatched fork, reproducing the 30 id flips byte-for-byte; the same replay against the patched fork produces no cascade.
- [x] Clean mid-list inserts still produce the correct shape under the patch.
- [ ] Consumer-side bump in `gamma-app/gamma` once `1.2.3-6` publishes (separate PR, blocked on this).

## Risk

Low. The patch only adds an early-skip on already-set identity attrs (`id`, `itemId`). No behavior change for fresh elements — they still receive their initial id assignment because `yDomAttrs[key] === undefined` the first time around. No other attrs are affected. The `id`/`itemId` set is the conservative subset of UniqueAttribute-managed keys in gamma; if other identity attrs need protection later, the list is extensible.

The deeper question of *why* the mapping desyncs in the first place (the `_typeChanged` rebuild path, the bulk-buddy amplifier, fresh PM refs from `CardLayoutPlugin.appendTransaction`) is not addressed by this PR. Those are followup work in `gamma-app/gamma` (Buddy bulk-edit batching) and possibly in this fork (length-mismatch assertion in `populateMapping`).

## Versioning

Bumped to `1.2.3-6` (matches the existing `1.2.3-N` cadence on master). Consumers in `gamma-app/gamma` will need to bump their dependency once this lands.
