### PR TITLE
Improve diffDocs error logging for Sentry

### DIFF
--- a/src/plugins/sync-plugin.js
+++ b/src/plugins/sync-plugin.js
@@ -730,12 +730,15 @@ export class ProsemirrorBinding {
         this.mapping.clear()
         populateMapping(this.type, tr.doc, this.mapping)
       } else {
-        console.error(
-          '[@gamma-app/y-prosemirror][sync-plugin] diffDocs produced an incorrect document',
-          this.prosemirrorView.state.doc.toJSON(),
-          _tr.doc.toJSON(),
-          tr.doc.toJSON()
-        )
+        try {
+          console.error('[@gamma-app/y-prosemirror][sync-plugin] diffDocs produced an incorrect document:', {
+            before: JSON.stringify(this.prosemirrorView.state.doc.toJSON()),
+            expected: JSON.stringify(_tr.doc.toJSON()),
+            actual: JSON.stringify(tr.doc.toJSON())
+          })
+        } catch (_e) {
+          console.error('[@gamma-app/y-prosemirror][sync-plugin] diffDocs produced an incorrect document; error forming error message:', _e)
+        }
         tr = _tr
       }
       restoreRelativeSelection(tr, this.beforeTransactionSelection, this)

--- a/src/plugins/sync-plugin.js
+++ b/src/plugins/sync-plugin.js
@@ -731,10 +731,11 @@ export class ProsemirrorBinding {
         populateMapping(this.type, tr.doc, this.mapping)
       } else {
         try {
+          const truncate = (s) => s.length > 4000 ? s.slice(0, 4000) + `…[truncated ${s.length - 4000} chars]` : s
           console.error('[@gamma-app/y-prosemirror][sync-plugin] diffDocs produced an incorrect document:', {
-            before: JSON.stringify(this.prosemirrorView.state.doc.toJSON()),
-            expected: JSON.stringify(_tr.doc.toJSON()),
-            actual: JSON.stringify(tr.doc.toJSON())
+            before: truncate(JSON.stringify(this.prosemirrorView.state.doc.toJSON())),
+            expected: truncate(JSON.stringify(_tr.doc.toJSON())),
+            actual: truncate(JSON.stringify(tr.doc.toJSON()))
           })
         } catch (_e) {
           console.error('[@gamma-app/y-prosemirror][sync-plugin] diffDocs produced an incorrect document; error forming error message:', _e)


### PR DESCRIPTION
Match the `createNodeFromYElement` logging pattern so Sentry gets a clean message and more readable doc JSON in the event body instead of `[object Object]`.

Add extra try/catch to be extra careful, also matches our other logs.

Truncated to match Sentry's 16KB limit... which might make these logs a lot less useful :(

## Currently

<img width="1500" alt="CleanShot 2026-05-13 at 20 13 33@2x" src="https://github.com/user-attachments/assets/6ec0d3fc-9975-41a3-ac78-8118e99bdd94" />

## `createNodeFromYElement`
<img width="1500" alt="CleanShot 2026-05-13 at 20 21 30@2x" src="https://github.com/user-attachments/assets/20409fa4-7554-4eb4-90bf-3ea7db9f3527" />


<!-- screenshots -->