### PR TITLE
Backport: fix incorrect node updates from wrong right-side match (upstream PR #192)

### DIFF
--- a/src/plugins/sync-plugin.js
+++ b/src/plugins/sync-plugin.js
@@ -1244,7 +1244,7 @@ export const updateYFragment = (y, yDomFragment, pNode, mapping) => {
     }
   }
   // find number of matching elements from right
-  for (; right + left + 1 < minCnt; right++) {
+  for (; right + left < minCnt; right++) {
     const rightY = yChildren[yChildCnt - right - 1]
     const rightP = pChildren[pChildCnt - right - 1]
     if (!mappedIdentity(mapping.get(rightY), rightP)) {

--- a/tests/y-prosemirror.test.js
+++ b/tests/y-prosemirror.test.js
@@ -220,6 +220,47 @@ export const testRestoreRelativePositionRetainsNodeSelection = tc => {
   t.assert(view.state.selection instanceof NodeSelection, 'node selection is retained')
 }
 
+export const testInsertRightMatch = (_tc) => {
+  const ydoc = new Y.Doc()
+  const yXmlFragment = ydoc.get('prosemirror', Y.XmlFragment)
+  const view = createNewProsemirrorView(ydoc)
+  view.dispatch(
+    view.state.tr.insert(
+      0,
+      [
+        schema.node(
+          'heading',
+          { level: 1 },
+          schema.text('Heading 1')
+        ),
+        schema.node(
+          'paragraph',
+          undefined,
+          schema.text('Paragraph 1')
+        )
+      ]
+    )
+  )
+  prosemirrorJSONToYXmlFragment(/** @type {any} */ (schema), view.state.doc.toJSON(), yXmlFragment)
+  const lastP = yXmlFragment.get(yXmlFragment.length - 1)
+  const tr = view.state.tr
+  view.dispatch(
+    tr.insert(
+      tr.doc.child(0).nodeSize + tr.doc.child(1).nodeSize,
+      schema.node(
+        'paragraph',
+        undefined,
+        schema.text('Paragraph 2')
+      )
+    )
+  )
+  const newLastP = yXmlFragment.get(yXmlFragment.length - 1)
+  const new2ndLastP = yXmlFragment.get(yXmlFragment.length - 2)
+  t.assert(lastP === newLastP, 'last paragraph is the same as before')
+  t.assert(new2ndLastP.toString() === '<paragraph>Paragraph 2</paragraph>', '2nd last paragraph is the inserted paragraph')
+  t.assert(lastP.toString() === '<paragraph></paragraph>', 'last paragraph remains empty and is placed at the end')
+}
+
 export const testAddToHistory = (_tc) => {
   const ydoc = new Y.Doc()
   const view = createNewProsemirrorViewWithUndoManager(ydoc)


### PR DESCRIPTION
## What

Backport of upstream **[yjs/y-prosemirror#192](https://github.com/yjs/y-prosemirror/pull/192)** — "Fix incorrect node updates by wrong right side match".

We're significantly behind upstream, so this is a piecemeal cherry-pick of just this fix.

## The bug

In `updateYFragment`, the loop that counts matching elements from the right stopped one element too early:

```diff
-  for (; right + left + 1 < minCnt; right++) {
+  for (; right + left < minCnt; right++) {
```

When inserting content between existing nodes, this off-by-one caused the sync logic to **update the last node in place and insert a new trailing node**, instead of **inserting the new node and leaving the existing trailing node's identity intact**.

In Yjs, "update in place vs. insert" determines which underlying Y type keeps its identity — so mis-attributing the edit destabilizes concurrent editing and relative positions. The upstream reporter hit this with multiple agents writing simultaneously.

## Changes

- `src/plugins/sync-plugin.js` — the one-character loop-condition fix.
- `tests/y-prosemirror.test.js` — ports the upstream `testInsertRightMatch` test. Placed before `testAddToHistory` (upstream put it after `testInsertDuplication`, which we don't have yet).

## Verification

- Full suite green (`npm test`, 15/15).
- Confirmed the new test is meaningful: with the fix reverted it fails (`Assertion failed: last paragraph is the same as before`); with the fix it passes.

## Notes

- Our `updateYFragment` is on an older base than upstream (we still use the `mapping` arg directly; upstream refactored to `meta.mapping`). The fix is independent of that refactor and applies cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)