### PR TITLE
Update our version number 1.2.3-7 for release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gamma-app/y-prosemirror",
-  "version": "1.2.3-6",
+  "version": "1.2.3-7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@gamma-app/y-prosemirror",
-      "version": "1.2.3-6",
+      "version": "1.2.3-7",
       "license": "MIT",
       "dependencies": {
         "lib0": "^0.2.42"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gamma-app/y-prosemirror",
-  "version": "1.2.3-6",
+  "version": "1.2.3-7",
   "description": "Prosemirror bindings for Yjs",
   "main": "./dist/y-prosemirror.cjs",
   "module": "./src/y-prosemirror.js",


### PR DESCRIPTION
Bump version number to next version of our fork, 1.2.3-7, after this change:  https://github.com/gamma-app/y-prosemirror/pull/30